### PR TITLE
User deletion did not work

### DIFF
--- a/src/Users/UserMappingTrait.php
+++ b/src/Users/UserMappingTrait.php
@@ -87,9 +87,18 @@ trait UserMappingTrait
 	 */
 	public function addRelations(Fluent $builder)
 	{
-		$this->hasMany('persistences', $builder);
-		$this->hasMany('reminders',    $builder);
-		$this->hasMany('activations', $builder)->orderBy('createdAt', 'desc');
+		$this->hasMany('persistences', $builder)
+			->cascadeAll()
+			->orphanRemoval();
+
+		$this->hasMany('reminders', $builder)
+			->cascadeAll()
+			->orphanRemoval();
+
+		$this->hasMany('activations', $builder)
+			->cascadeAll()
+			->orphanRemoval()
+			->orderBy('createdAt', 'desc');
 
 		if ($this->enabled['throttles'])
 		{


### PR DESCRIPTION
Added cascadeAll and orphanRemoval for satellite tables.
Seems that `$this->hasMany('throttles', $builder);` should also have cascade and orphanRemoval, but with that, the deletion fails. Don't know why.
