### PR TITLE
FIX | Logout "everywhere"

### DIFF
--- a/src/Persistences/DoctrinePersistenceRepository.php
+++ b/src/Persistences/DoctrinePersistenceRepository.php
@@ -187,24 +187,26 @@ abstract class DoctrinePersistenceRepository extends EntityRepository implements
      */
     public function flush(PersistableInterface $persistable, bool $forget = true): void
     {
+        $code = $this->check();
+
         if ($forget) {
             $this->forget();
         }
-
-        $code = $this->check();
 
         $entityManager = $this->getEntityManager();
         $queryBuilder = $entityManager->createQueryBuilder();
 
         $queryBuilder
             ->delete($this->entityName(), 'p')
-            ->where('p.user = :persistable')
-            ->andWhere('p.code != :code');
+            ->where('p.user = :persistable');
+        
+        if ($code) {
+            $queryBuilder
+                ->andWhere('p.code != :code')
+                ->setParameter('code', $code);
+        }
 
-        $queryBuilder->setParameters([
-            'persistable' => $persistable,
-            'code' => $code,
-        ]);
+        $queryBuilder->setParameter('persistable', $persistable);
 
         $queryBuilder->getQuery()->execute();
     }

--- a/src/Persistences/DoctrinePersistenceRepository.php
+++ b/src/Persistences/DoctrinePersistenceRepository.php
@@ -198,15 +198,14 @@ abstract class DoctrinePersistenceRepository extends EntityRepository implements
 
         $queryBuilder
             ->delete($this->entityName(), 'p')
-            ->where('p.user = :persistable');
+            ->where('p.user = :persistable')
+            ->setParameter('persistable', $persistable);
         
         if ($code) {
             $queryBuilder
                 ->andWhere('p.code != :code')
                 ->setParameter('code', $code);
         }
-
-        $queryBuilder->setParameter('persistable', $persistable);
 
         $queryBuilder->getQuery()->execute();
     }


### PR DESCRIPTION
```
if ($forget) {
    $this->forget();
}

$code = $this->check();
```

Al llamar primero a **forget** (siempre es **true**, _ya que Sentinel no le pasa ningún valor y el parámetro por defecto es true_) **$this->check() devuelve siempre NULL**.

Teniendo en cuenta lo anteriormente dicho, la query final que se ejecuta es:
`DELETE FROM persistences WHERE user_id = ? AND code <> ?`

como **code = NULL**, nos queda la siguiente query (suponiendo que el user_id es 1):
`DELETE FROM persistences WHERE user_id = 1 AND code <> NULL;`

Esto al fin de cuentas no elimina nada, para corroborarlo, podémos ejecutar la siguiente query, que devuelve un empty set:
`SELECT * FROM persistences WHERE user_id = 1 AND code <> NULL;`

El FIX acá está en utilizar **WHERE NOT** en lugar de <>, siempre y cuando el code sea NULL.